### PR TITLE
Provide repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "reading",
     "time"
   ],
-  "repository": "",
+  "repository": "https://github.com/peopledoc/ember-reading-time",
   "license": "MIT",
   "author": "",
   "directories": {


### PR DESCRIPTION
I had a little trouble locating this repo from npmjs.com and emberobserver.com because this field was missing.